### PR TITLE
Add automatic .uf2 release and optional status LED

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,41 @@
+name: Build and Release Firmware
+
+on:
+  push:
+    tags:
+      - 'v*' # Triggers when you push a tag like v1.0, v0.9, etc.
+
+permissions:
+  contents: write # Required to allow the Action to create a Release
+
+jobs:
+  build_and_release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Install Arm Toolchain & CMake
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential cmake
+
+    - name: Configure CMake
+      # We pass -DPICO_SDK_FETCH_FROM_GIT=ON so the build system downloads the SDK automatically
+      run: |
+        mkdir build
+        cd build
+        cmake .. -DPICO_SDK_FETCH_FROM_GIT=ON
+
+    - name: Compile Firmware
+      run: |
+        cd build
+        make
+
+    - name: Create Release & Upload UF2
+      uses: softprops/action-gh-release@v2
+      with:
+        files: build/gbusb.uf2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ CMakeCache.txt
 pico-sdk
 spi.pio.h
 cmake_install.cmake
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.13)
 # note: this must happen before project()
 include(pico_sdk_import.cmake)
 project(gbusb)
- 
+
 pico_sdk_init()
 
 add_executable(gbusb)
@@ -14,13 +14,12 @@ target_include_directories(gbusb PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
 target_sources(gbusb PRIVATE
         main.c
-
         usb_descriptors.c
-
         # PIO components
         pio/pio_spi.c
         )
-        
-target_link_libraries(gbusb PRIVATE pico_stdlib hardware_pio tinyusb_device tinyusb_board)
-pico_add_extra_outputs(gbusb)
 
+# (hardware_clocks  required for WS2812 timing calculations)
+target_link_libraries(gbusb PRIVATE pico_stdlib hardware_pio hardware_clocks tinyusb_device tinyusb_board)
+
+pico_add_extra_outputs(gbusb)

--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ The onboard RGB LED (GP16) indicates the current connection status:
     make
     ```
 3.  **Flash:** Hold the `BOOT` button on the RP2040, plug it in, and drag the generated `.uf2` file into the `RPI-RP2` drive.
+
+Print functionality derived from firmware at https://github.com/stacksmashing/gb-link-printer

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+# GB-Link USB  -  RP2040 Game Boy Link Adapter Firmware
+
+This firmware turns an RP2040 into a USB-to-Game Boy Link Cable adapter. It supports WebUSB for browser-based communication and a standard CDC Serial interface.
+
+## Hardware Required
+* **Controler board:** Pi-Pico or Waveshare RP2040-Zero (For LED functions)
+* **Level shifter/connector board:** This one for standard Pi-Pico https://github.com/agtbaskara/game-boy-pico-link-board or this one for RP2040-Zero https://github.com/weimanc/game-boy-zero-link-board
+
+## Wiring Guide
+The firmware uses the RP2040 PIO (Programmable I/O) to communicate with the Game Boy. Connect the Link Cable wires to the RP2040 header pins as follows:
+
+| Game Boy Signal | RP2040 Pin |
+| :--- | :--- |
+| **SCK** (Clock) | **GP0** |
+| **SIN** (Data In) | **GP1** |
+| **SOUT** (Data Out)| **GP2** |
+| **SD** (Chip Select)| **GP3** |
+| **GND** | **Ground** |
+
+
+## LED Status Indicators (only for RP2040Zero with onboard WS2812)
+The onboard RGB LED (GP16) indicates the current connection status:
+
+| Color | Status | Description |
+| :--- | :--- | :--- |
+| **Red** | **Disconnected** | Device powered, but USB data not enumerated. |
+| **Green** | **Mounted** | USB connected successfully to the host computer. |
+| **Blue** | **Active** | WebUSB session active (browser connected). |
+
+## Building the Firmware
+
+1.  **Install SDK:** Ensure you have the Raspberry Pi Pico SDK installed and configured.
+2.  **Build:**
+    ```bash
+    mkdir build
+    cd build
+    cmake ..
+    make
+    ```
+3.  **Flash:** Hold the `BOOT` button on the RP2040, plug it in, and drag the generated `.uf2` file into the `RPI-RP2` drive.

--- a/README.md
+++ b/README.md
@@ -39,4 +39,8 @@ The onboard RGB LED (GP16) indicates the current connection status:
     ```
 3.  **Flash:** Hold the `BOOT` button on the RP2040, plug it in, and drag the generated `.uf2` file into the `RPI-RP2` drive.
 
+## Troubleshooting
+- Currently when refreshing the web page on WebUSB devices the pico/usb device needs to be reset. Unplugging or pressing reset on the USB adapter should acomplish this
+- If on linux you may need to edit Udev rules. See here https://stackoverflow.com/questions/30983221/chrome-app-fails-to-open-usb-device
+
 Print functionality derived from firmware at https://github.com/stacksmashing/gb-link-printer

--- a/main.c
+++ b/main.c
@@ -37,12 +37,30 @@
 #include "pico/time.h"
 #include "hardware/clocks.h"
 
-// --- WS2812 PIO DRIVER ADDITION ---
+// --- WS2812 PIO DRIVER (from official pico-examples) ---
+// This is the exact WS2812 PIO program from the Raspberry Pi Pico examples
+// Program: .side_set 1
+//   .wrap_target
+//   bitloop:
+//       out x, 1       side 0 [T3 - 1] ; T3 = 3
+//       jmp !x do_zero side 1 [T1 - 1] ; T1 = 2
+//   do_one:
+//       jmp  bitloop   side 1 [T2 - 1] ; T2 = 3
+//   do_zero:
+//       nop            side 0 [T2 - 1]
+//   .wrap
+
+#define WS2812_T1 2
+#define WS2812_T2 3
+#define WS2812_T3 3
+
 static const uint16_t ws2812_program_instructions[] = {
-    0x6221, //  0: out    x, 1            side 0 [2] 
-    0x1123, //  1: jmp    !x, 3           side 1 [1] 
-    0x1100, //  2: jmp    0               side 1 [1] 
-    0xa442, //  3: nop                    side 0 [4] 
+    //     .wrap_target
+    0x6221, //  0: out    x, 1            side 0 [2]
+    0x1123, //  1: jmp    !x, 3           side 1 [1]
+    0x1400, //  2: jmp    0               side 1 [2]
+    0xa442, //  3: nop                    side 0 [4]
+    //     .wrap
 };
 
 static const struct pio_program ws2812_program = {
@@ -51,35 +69,32 @@ static const struct pio_program ws2812_program = {
     .origin = -1,
 };
 
-void ws2812_program_init(PIO pio, uint sm, uint offset, uint pin, float freq, bool rgbw) {
-    // Ensure clean state - critical for proper operation after reset
-    pio_sm_set_enabled(pio, sm, false);
-    pio_sm_clear_fifos(pio, sm);
-    pio_sm_restart(pio, sm);
-    
+static inline void ws2812_program_init(PIO pio, uint sm, uint offset, uint pin, float freq, bool rgbw) {
     pio_gpio_init(pio, pin);
     pio_sm_set_consecutive_pindirs(pio, sm, pin, 1, true);
-    
+
     pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_sideset(&c, 1, false, false);  // 1 sideset bit, not optional, no pindirs
+    sm_config_set_sideset(&c, 1, false, false);
     sm_config_set_sideset_pins(&c, pin);
     sm_config_set_out_shift(&c, false, true, rgbw ? 32 : 24);
     sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_TX);
-    sm_config_set_wrap(&c, offset, offset + 3);  // Wrap from instruction 3 back to 0
-    int cycles_per_bit = (1 + 1 + 2) + (1 + 1 + 2) + (1 + 1 + 4);
+    sm_config_set_wrap(&c, offset + 0, offset + 3);
+
+    int cycles_per_bit = WS2812_T1 + WS2812_T2 + WS2812_T3;
     float div = clock_get_hz(clk_sys) / (freq * cycles_per_bit);
     sm_config_set_clkdiv(&c, div);
-    
+
     pio_sm_init(pio, sm, offset, &c);
     pio_sm_set_enabled(pio, sm, true);
 }
 
-// Helper: Sets the color. Format: 0x00GGRRBB
-void set_neopixel(uint32_t pixel_grb) {
-    // Uses PIO0, SM0 to avoid conflict with SPI on PIO1
+static inline void put_pixel(uint32_t pixel_grb) {
     pio_sm_put_blocking(pio0, 0, pixel_grb << 8u);
-    // WS2812 needs ~50us reset time between updates, but the blink interval
-    // is long enough that this is handled naturally
+}
+
+// Helper: Sets the color. Format: 0xGGRRBB (Green, Red, Blue)
+void set_neopixel(uint32_t pixel_grb) {
+    put_pixel(pixel_grb);
 }
 
 #define NUM_CMP_BYTES 0x20

--- a/main.c
+++ b/main.c
@@ -55,13 +55,15 @@ void ws2812_program_init(PIO pio, uint sm, uint offset, uint pin, float freq, bo
     pio_gpio_init(pio, pin);
     pio_sm_set_consecutive_pindirs(pio, sm, pin, 1, true);
     pio_sm_config c = pio_get_default_sm_config();
+    sm_config_set_sideset(&c, 1, false, false);  // 1 sideset bit, not optional, no pindirs
     sm_config_set_sideset_pins(&c, pin);
     sm_config_set_out_shift(&c, false, true, rgbw ? 32 : 24);
     sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_TX);
+    sm_config_set_wrap(&c, offset, offset + 3);  // Wrap from instruction 3 back to 0
     int cycles_per_bit = (1 + 1 + 2) + (1 + 1 + 2) + (1 + 1 + 4);
     float div = clock_get_hz(clk_sys) / (freq * cycles_per_bit);
     sm_config_set_clkdiv(&c, div);
-    pio_sm_init(pio, sm, offset + (rgbw ? 0 : 4), &c);
+    pio_sm_init(pio, sm, offset, &c);  // Always start at offset 0 of the program
     pio_sm_set_enabled(pio, sm, true);
 }
 
@@ -450,3 +452,4 @@ void led_blinking_task(void)
      set_neopixel(0x000000); // Off
   }
 }
+

--- a/main.c
+++ b/main.c
@@ -125,7 +125,7 @@ static uint8_t led_magic_header[LED_MAGIC_HEADER_LEN] = {
 #define VSWITCH_5V_PIN  12
 
 uint PIN_SOUT = 2;
-uint SI_PIN = 3;
+uint SD_PIN = 3;
 
 bool is_test_pin_grounded() {
   gpio_init(TEST_PIN);
@@ -223,14 +223,14 @@ int main(void)
 {
   // Check the state of TEST_PIN
   if (is_test_pin_grounded()) {
-    // GPIO 6 (TEST_PIN) is grounded, update PIN_SOUT and SI_PIN
+    // GPIO 6 (TEST_PIN) is grounded, update PIN_SOUT and SD_PIN
     PIN_SOUT = 3;
-    SI_PIN = 4;
+    SD_PIN = 4;
   }
   else {
     // GPIO 6 (TEST_PIN) is not grounded, use default values
     PIN_SOUT = 2;
-    SI_PIN = 3;
+    SD_PIN = 3;
   }
 
   vswitch_init();

--- a/main.c
+++ b/main.c
@@ -125,7 +125,7 @@ static uint8_t led_magic_header[LED_MAGIC_HEADER_LEN] = {
 #define VSWITCH_5V_PIN  12
 
 uint PIN_SOUT = 2;
-uint SI_PIN = 3;
+uint SD_PIN = 3;
 
 bool is_test_pin_grounded() {
   gpio_init(TEST_PIN);
@@ -223,14 +223,14 @@ int main(void)
 {
   // Check the state of TEST_PIN
   if (is_test_pin_grounded()) {
-    // GPIO 6 (TEST_PIN) is grounded, update PIN_SOUT and SI_PIN
+    // GPIO 6 (TEST_PIN) is grounded, update PIN_SOUT and SD_PIN
     PIN_SOUT = 3;
-    SI_PIN = 4;
+    SD_PIN = 4;
   }
   else {
     // GPIO 6 (TEST_PIN) is not grounded, use default values
     PIN_SOUT = 2;
-    SI_PIN = 3;
+    SD_PIN = 3;
   }
 
   vswitch_init();
@@ -241,6 +241,15 @@ int main(void)
   buf_count = 0;
   uint cpha1_prog_offs = pio_add_program(spi.pio, &spi_cpha1_program);
   pio_spi_init(spi.pio, spi.sm, cpha1_prog_offs, 8, 4058.838/128, 1, 1, PIN_SCK, PIN_SOUT, PIN_SIN);
+
+  // Drive SD (cable pin 4) LOW so the GBA detects the adapter as an external
+  // clock master (GBA reads this via SIOCNT bit 3). Generic GBC cables wire
+  // pin 4 through to the GBA; OEM GBC cables leave it unconnected, so this
+  // is harmless there. SD_PIN tracks the correct GPIO for both hardware
+  // variants (3 in default layout, 4 in the shifted/test-pin layout).
+  gpio_init(SD_PIN);
+  gpio_set_dir(SD_PIN, GPIO_OUT);
+  gpio_put(SD_PIN, 0);
 
   tusb_init();
 

--- a/main.c
+++ b/main.c
@@ -203,9 +203,6 @@ const tusb_desc_webusb_url_t desc_url =
 
 static bool web_serial_connected = false;
 
-// Firmware version returned via control transfer (request 0x23)
-static const char FIRMWARE_VERSION_STR[] = "GBLINK:1.0.6";
-
 //------------- prototypes -------------//
 void handle_input_data(uint8_t* buf_in, uint32_t count);
 void data_transfer_task(void);
@@ -377,10 +374,6 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
       // response with status OK
       return tud_control_status(rhport, request);
       break;
-
-    case 0x23:
-      // Firmware version query
-      return tud_control_xfer(rhport, request, (void*)FIRMWARE_VERSION_STR, sizeof(FIRMWARE_VERSION_STR) - 1);
 
     default: break;
   }

--- a/main.c
+++ b/main.c
@@ -36,6 +36,9 @@
 #include "pio/pio_spi.h"
 #include "pico/time.h"
 #include "hardware/clocks.h"
+#include "hardware/flash.h"
+#include "hardware/sync.h"
+#include "hardware/watchdog.h"
 
 // --- WS2812 NeoPixel PIO Driver ---
 static const uint16_t ws2812_program_instructions[] = {
@@ -115,6 +118,135 @@ static uint8_t led_magic_header[LED_MAGIC_HEADER_LEN] = {
     'L', 'E', 'D', 'S'  // "LEDS" to indicate LED color command
 };
 
+// WebUSB landing-page toggle: 36-byte header + 1 value byte = 37 bytes total.
+// value 0x00 = disable, 0x01 = enable, 0xFF = query only. Always responds with
+// the current state (0/1). Persisted in flash; applies on the next reconnect.
+#define LANDING_MAGIC_LEN 37
+#define LANDING_MAGIC_HEADER_LEN 36
+static uint8_t landing_magic_header[LANDING_MAGIC_HEADER_LEN] = {
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    'L', 'A', 'N', 'D'  // "LAND" to indicate landing-page toggle/query
+};
+
+// Per-mode LED colour commands. Both use length 40 (like the live "LEDS"
+// command) and are distinguished by the 4-char tag at offset 32 — length 40
+// avoids the 36-byte timing command, which only matches the 32-byte prefix.
+//   LEDM (set):  32-byte prefix + "LEDM" + [slot, r, g, b]
+//   LEDG (query): 32-byte prefix + "LEDG" + 4 ignored bytes  -> replies [count, rgb...]
+#define LED_CMD_MAGIC_LEN 40
+#define LED_CMD_HEADER_LEN 36
+static uint8_t led_mode_magic_header[LED_CMD_HEADER_LEN] = {
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    'L', 'E', 'D', 'M'
+};
+static uint8_t led_get_magic_header[LED_CMD_HEADER_LEN] = {
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    'L', 'E', 'D', 'G'
+};
+static uint8_t led_reset_magic_header[LED_CMD_HEADER_LEN] = {
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    'L', 'E', 'D', 'R'
+};
+// Warm-reboot the board into the app (not the bootloader) so persisted settings
+// apply now: 32-byte prefix + "BOOT". Same length (40) as the LED family.
+static uint8_t reboot_magic_header[LED_CMD_HEADER_LEN] = {
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    'B', 'O', 'O', 'T'
+};
+
+// Persistent settings (last 4 KB flash sector, well past the ~55 KB app): the
+// WebUSB landing-page flag and per-mode LED colours. One versioned struct;
+// erased/old flash falls back to defaults via the magic/version check.
+#define SETTINGS_FLASH_OFFSET (PICO_FLASH_SIZE_BYTES - FLASH_SECTOR_SIZE)
+#define SETTINGS_MAGIC 0x5A
+#define SETTINGS_VERSION 4  // bumped to re-default the LED colours
+#define RECFG_LED_SLOTS 3  // 0 = connected, 1 = active/link, 2 = printer
+
+typedef struct {
+    uint8_t magic;
+    uint8_t version;
+    uint8_t landing;                  // 0 = disabled, else enabled
+    uint8_t led[RECFG_LED_SLOTS][3];  // logical RGB
+} persist_settings_t;
+
+// Real-colour defaults at a uniform 50% brightness (128/255).
+static const uint8_t recfg_default_colors[RECFG_LED_SLOTS][3] = {
+    { 0,   128, 0   }, // connected — green
+    { 0,   0,   128 }, // active / link — blue
+    { 128, 0,   128 }, // printer — purple
+};
+
+static void load_settings(persist_settings_t *s) {
+    memcpy(s, (const void *)(XIP_BASE + SETTINGS_FLASH_OFFSET), sizeof(*s));
+    if (s->magic != SETTINGS_MAGIC || s->version != SETTINGS_VERSION) {
+        s->magic = SETTINGS_MAGIC;
+        s->version = SETTINGS_VERSION;
+        s->landing = 1;
+        memcpy(s->led, recfg_default_colors, sizeof(s->led));
+    }
+}
+
+static void save_settings(const persist_settings_t *s) {
+    uint8_t page[FLASH_PAGE_SIZE];
+    memset(page, 0xFF, sizeof(page));
+    memcpy(page, s, sizeof(*s));
+    uint32_t ints = save_and_disable_interrupts();
+    flash_range_erase(SETTINGS_FLASH_OFFSET, FLASH_SECTOR_SIZE);
+    flash_range_program(SETTINGS_FLASH_OFFSET, page, FLASH_PAGE_SIZE);
+    restore_interrupts(ints);
+}
+
+bool landing_page_enabled(void) {
+    persist_settings_t s; load_settings(&s);
+    return s.landing != 0;
+}
+
+void set_landing_page_enabled(bool enabled) {
+    persist_settings_t s; load_settings(&s);
+    s.landing = enabled ? 1 : 0;
+    save_settings(&s);
+}
+
+static void get_led_color(uint8_t slot, uint8_t out[3]) {
+    if (slot >= RECFG_LED_SLOTS) { out[0] = out[1] = out[2] = 0; return; }
+    persist_settings_t s; load_settings(&s);
+    out[0] = s.led[slot][0]; out[1] = s.led[slot][1]; out[2] = s.led[slot][2];
+}
+
+static void set_led_color(uint8_t slot, uint8_t r, uint8_t g, uint8_t b) {
+    if (slot >= RECFG_LED_SLOTS) return;
+    persist_settings_t s; load_settings(&s);
+    s.led[slot][0] = r; s.led[slot][1] = g; s.led[slot][2] = b;
+    save_settings(&s);
+}
+
+static void reset_led_colors(void) {
+    persist_settings_t s; load_settings(&s);
+    memcpy(s.led, recfg_default_colors, sizeof(s.led));
+    save_settings(&s);
+}
+
+// Apply a slot's stored colour now. set_neopixel wants GRB.
+static void apply_led_for_slot(uint8_t slot) {
+    uint8_t c[3]; get_led_color(slot, c);
+    set_neopixel(((uint32_t)c[1] << 16) | ((uint32_t)c[0] << 8) | c[2]);
+}
+
 #define PIN_SCK 0
 #define PIN_SIN 1
 #define TEST_PIN 6
@@ -191,7 +323,7 @@ static uint8_t num_bytes_per_transfer = NUM_DEFAULT_BYTES_PER_TRANSFER;
 static uint32_t us_between_transfer = US_DEFAULT_PER_TRANSFER;
 static uint32_t total_transferred = 0;
 
-#define URL  "tetris.gblink.io"
+#define URL  "launcher.gblink.io"
 
 const tusb_desc_webusb_url_t desc_url =
 {
@@ -364,10 +496,10 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
       us_between_transfer = US_DEFAULT_PER_TRANSFER;
 
       if (web_serial_connected) {
-        set_neopixel(0x000005); // Blue (Active)
+        apply_led_for_slot(1); // active / link
         blink_interval_ms = BLINK_ALWAYS_ON;
       } else {
-        set_neopixel(0x050000); // Green (Mounted) - immediate feedback
+        apply_led_for_slot(0); // connected
         blink_interval_ms = BLINK_MOUNTED;
       }
 
@@ -423,7 +555,7 @@ void handle_input_data(uint8_t* buf_in, uint32_t count) {
       uint8_t ack = 0x50; // 'P' for printer
       echo_all(&ack, 1);
       printer_mode = true;
-      set_neopixel(0x050005); // Purple for printer mode
+      apply_led_for_slot(2); // printer
       
       // Disable PIO SPI and reconfigure pins for GPIO
       pio_sm_set_enabled(spi.pio, spi.sm, false);
@@ -434,7 +566,7 @@ void handle_input_data(uint8_t* buf_in, uint32_t count) {
       // Re-enable PIO SPI when exiting printer mode
       pio_sm_set_enabled(spi.pio, spi.sm, true);
       printer_mode = false;
-      set_neopixel(0x000005); // Blue (Active)
+      apply_led_for_slot(1); // active / link
       processed = 1;
     }
   }
@@ -483,6 +615,89 @@ void handle_input_data(uint8_t* buf_in, uint32_t count) {
       // Disable blink task from overriding the color
       blink_interval_ms = BLINK_ALWAYS_ON;
       uint8_t ack = 0x4C; // 'L' for LED
+      echo_all(&ack, 1);
+      processed = 1;
+    }
+  }
+
+  // Set a per-mode LED colour (persisted): prefix + "LEDM" + [slot, r, g, b]
+  if(!processed && count == LED_CMD_MAGIC_LEN) {
+    uint8_t is_ledm = 1;
+    for(int i = 0; i < LED_CMD_HEADER_LEN; i++) {
+      if(buf_in[i] != led_mode_magic_header[i]) { is_ledm = 0; break; }
+    }
+    if(is_ledm) {
+      set_led_color(buf_in[LED_CMD_HEADER_LEN], buf_in[LED_CMD_HEADER_LEN + 1],
+                    buf_in[LED_CMD_HEADER_LEN + 2], buf_in[LED_CMD_HEADER_LEN + 3]);
+      uint8_t ack = 0x4D; // 'M'
+      echo_all(&ack, 1);
+      processed = 1;
+    }
+  }
+
+  // Query per-mode LED colours: prefix + "LEDG" -> [count, r0,g0,b0, ...]
+  if(!processed && count == LED_CMD_MAGIC_LEN) {
+    uint8_t is_ledg = 1;
+    for(int i = 0; i < LED_CMD_HEADER_LEN; i++) {
+      if(buf_in[i] != led_get_magic_header[i]) { is_ledg = 0; break; }
+    }
+    if(is_ledg) {
+      uint8_t resp[1 + RECFG_LED_SLOTS * 3];
+      resp[0] = RECFG_LED_SLOTS;
+      for(uint8_t slot = 0; slot < RECFG_LED_SLOTS; slot++) {
+        get_led_color(slot, &resp[1 + slot * 3]);
+      }
+      echo_all(resp, sizeof(resp));
+      processed = 1;
+    }
+  }
+
+  // Reset per-mode LED colours to defaults: prefix + "LEDR"
+  if(!processed && count == LED_CMD_MAGIC_LEN) {
+    uint8_t is_ledr = 1;
+    for(int i = 0; i < LED_CMD_HEADER_LEN; i++) {
+      if(buf_in[i] != led_reset_magic_header[i]) { is_ledr = 0; break; }
+    }
+    if(is_ledr) {
+      reset_led_colors();
+      uint8_t ack = 0x52; // 'R'
+      echo_all(&ack, 1);
+      processed = 1;
+    }
+  }
+
+  // Warm-reboot into the app so saved settings apply now: prefix + "BOOT"
+  if(!processed && count == LED_CMD_MAGIC_LEN) {
+    uint8_t is_boot = 1;
+    for(int i = 0; i < LED_CMD_HEADER_LEN; i++) {
+      if(buf_in[i] != reboot_magic_header[i]) { is_boot = 0; break; }
+    }
+    if(is_boot) {
+      uint8_t ack = 0x42; // 'B'
+      echo_all(&ack, 1);
+      tud_vendor_flush();
+      // Let the ack drain to the host, then reboot. watchdog_reboot(0,0,delay)
+      // performs a normal boot back into the application.
+      busy_wait_ms(20);
+      watchdog_reboot(0, 0, 0); // does not return
+    }
+  }
+
+  // Check for WebUSB landing-page toggle/query magic sequence
+  if(!processed && count == LANDING_MAGIC_LEN) {
+    uint8_t is_land = 1;
+    for(int i = 0; i < LANDING_MAGIC_HEADER_LEN; i++) {
+      if(buf_in[i] != landing_magic_header[i]) {
+        is_land = 0;
+        break;
+      }
+    }
+    if(is_land) {
+      uint8_t value = buf_in[LANDING_MAGIC_HEADER_LEN];
+      if(value != 0xFF) {  // 0xFF = query only, don't change
+        set_landing_page_enabled(value != 0);
+      }
+      uint8_t ack = landing_page_enabled() ? 1 : 0;
       echo_all(&ack, 1);
       processed = 1;
     }
@@ -587,7 +802,7 @@ void led_blinking_task(void)
 
   if (led_state) {
     if (blink_interval_ms == BLINK_MOUNTED)
-      set_neopixel(0x050000); // Green
+      apply_led_for_slot(0); // connected
     else if (blink_interval_ms == BLINK_NOT_MOUNTED)
       set_neopixel(0x000500); // Red
   } else {

--- a/main.c
+++ b/main.c
@@ -87,10 +87,31 @@ static uint8_t printer_mode_magic[PRINTER_MODE_MAGIC_LEN] = {
 };
 static bool printer_mode = false;
 
+// Voltage switch magic packets (36 bytes each, same length as printer mode)
+#define VSWITCH_MAGIC_LEN 36
+static uint8_t vswitch_3v3_magic[VSWITCH_MAGIC_LEN] = {
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    'V', '3', 'V', '3'  // "V3V3" to indicate 3.3V mode
+};
+static uint8_t vswitch_5v_magic[VSWITCH_MAGIC_LEN] = {
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    'V', '5', 'V', '0'  // "V5V0" to indicate 5V mode
+};
+
 #define PIN_SCK 0
 #define PIN_SIN 1
 #define TEST_PIN 6
 #define WS2812_PIN 16
+
+// Voltage switch GPIO pins
+#define VSWITCH_3V3_PIN 11
+#define VSWITCH_5V_PIN  12
 
 uint PIN_SOUT = 2;
 uint SI_PIN = 3;
@@ -104,6 +125,33 @@ bool is_test_pin_grounded() {
   bool grounded = gpio_get(TEST_PIN) == 0;
 
   return grounded;
+}
+
+// Voltage switch control: set both HIGH first (safe off), then pull one LOW
+void vswitch_set_3v3(void) {
+  gpio_put(VSWITCH_3V3_PIN, 1);
+  gpio_put(VSWITCH_5V_PIN, 1);
+  busy_wait_us(100);
+  gpio_put(VSWITCH_3V3_PIN, 0);
+}
+
+void vswitch_set_5v(void) {
+  gpio_put(VSWITCH_3V3_PIN, 1);
+  gpio_put(VSWITCH_5V_PIN, 1);
+  busy_wait_us(100);
+  gpio_put(VSWITCH_5V_PIN, 0);
+}
+
+void vswitch_init(void) {
+  gpio_init(VSWITCH_3V3_PIN);
+  gpio_init(VSWITCH_5V_PIN);
+  gpio_set_dir(VSWITCH_3V3_PIN, GPIO_OUT);
+  gpio_set_dir(VSWITCH_5V_PIN, GPIO_OUT);
+  // Start both HIGH (safe), then enable 3.3V as default
+  gpio_put(VSWITCH_3V3_PIN, 1);
+  gpio_put(VSWITCH_5V_PIN, 1);
+  busy_wait_us(100);
+  gpio_put(VSWITCH_3V3_PIN, 0); // 3.3V mode (default)
 }
 
 //--------------------------------------------------------------------+
@@ -143,6 +191,11 @@ const tusb_desc_webusb_url_t desc_url =
 };
 
 static bool web_serial_connected = false;
+static bool send_firmware_version = false;
+
+// Firmware version string sent on WebSerial connect
+#define FIRMWARE_VERSION_STR "GBLINK:1.0.6\n"
+#define FIRMWARE_VERSION_LEN (sizeof(FIRMWARE_VERSION_STR) - 1)
 
 //------------- prototypes -------------//
 void handle_input_data(uint8_t* buf_in, uint32_t count);
@@ -173,6 +226,8 @@ int main(void)
     PIN_SOUT = 2;
     SI_PIN = 3;
   }
+
+  vswitch_init();
 
   board_init();
   uint offset = pio_add_program(pio0, &ws2812_program);
@@ -305,6 +360,7 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
       if (web_serial_connected) {
         set_neopixel(0x000005); // Blue (Active)
         blink_interval_ms = BLINK_ALWAYS_ON;
+        send_firmware_version = true;
       } else {
         set_neopixel(0x050000); // Green (Mounted) - immediate feedback
         blink_interval_ms = BLINK_MOUNTED;
@@ -378,6 +434,27 @@ void handle_input_data(uint8_t* buf_in, uint32_t count) {
     }
   }
   
+  // Check for voltage switch magic sequences
+  if(!processed && count == VSWITCH_MAGIC_LEN) {
+    uint8_t is_3v3 = 1, is_5v = 1;
+    for(int i = 0; i < VSWITCH_MAGIC_LEN; i++) {
+      if(buf_in[i] != vswitch_3v3_magic[i]) is_3v3 = 0;
+      if(buf_in[i] != vswitch_5v_magic[i]) is_5v = 0;
+      if(!is_3v3 && !is_5v) break;
+    }
+    if(is_3v3) {
+      vswitch_set_3v3();
+      uint8_t ack = 0x33; // '3' for 3.3V
+      echo_all(&ack, 1);
+      processed = 1;
+    } else if(is_5v) {
+      vswitch_set_5v();
+      uint8_t ack = 0x35; // '5' for 5V
+      echo_all(&ack, 1);
+      processed = 1;
+    }
+  }
+
   // Check for timing config magic sequence
   if(!processed && count == NUM_CMP_BYTES_RECV) {
     uint8_t failed = 0;
@@ -415,12 +492,20 @@ void handle_input_data(uint8_t* buf_in, uint32_t count) {
 
 void webserial_task(void)
 {
-  if ( web_serial_connected )
+  if ( web_serial_connected ) {
+    // Send firmware version string once after WebSerial connect
+    if (send_firmware_version) {
+      send_firmware_version = false;
+      tud_vendor_write((uint8_t*)FIRMWARE_VERSION_STR, FIRMWARE_VERSION_LEN);
+      tud_vendor_flush();
+    }
+
     if ( tud_vendor_available() ) {
       uint8_t buf_in[MAX_TRANSFER_BYTES*2];
       uint32_t count = tud_vendor_read(buf_in, sizeof(buf_in));
       handle_input_data(buf_in, count);
     }
+  }
 }
 
 

--- a/main.c
+++ b/main.c
@@ -125,7 +125,7 @@ static uint8_t led_magic_header[LED_MAGIC_HEADER_LEN] = {
 #define VSWITCH_5V_PIN  12
 
 uint PIN_SOUT = 2;
-uint SD_PIN = 3;
+uint SI_PIN = 3;
 
 bool is_test_pin_grounded() {
   gpio_init(TEST_PIN);
@@ -223,14 +223,14 @@ int main(void)
 {
   // Check the state of TEST_PIN
   if (is_test_pin_grounded()) {
-    // GPIO 6 (TEST_PIN) is grounded, update PIN_SOUT and SD_PIN
+    // GPIO 6 (TEST_PIN) is grounded, update PIN_SOUT and SI_PIN
     PIN_SOUT = 3;
-    SD_PIN = 4;
+    SI_PIN = 4;
   }
   else {
     // GPIO 6 (TEST_PIN) is not grounded, use default values
     PIN_SOUT = 2;
-    SD_PIN = 3;
+    SI_PIN = 3;
   }
 
   vswitch_init();
@@ -241,15 +241,6 @@ int main(void)
   buf_count = 0;
   uint cpha1_prog_offs = pio_add_program(spi.pio, &spi_cpha1_program);
   pio_spi_init(spi.pio, spi.sm, cpha1_prog_offs, 8, 4058.838/128, 1, 1, PIN_SCK, PIN_SOUT, PIN_SIN);
-
-  // Drive SD (cable pin 4) LOW so the GBA detects the adapter as an external
-  // clock master (GBA reads this via SIOCNT bit 3). Generic GBC cables wire
-  // pin 4 through to the GBA; OEM GBC cables leave it unconnected, so this
-  // is harmless there. SD_PIN tracks the correct GPIO for both hardware
-  // variants (3 in default layout, 4 in the shifted/test-pin layout).
-  gpio_init(SD_PIN);
-  gpio_set_dir(SD_PIN, GPIO_OUT);
-  gpio_put(SD_PIN, 0);
 
   tusb_init();
 

--- a/main.c
+++ b/main.c
@@ -104,6 +104,17 @@ static uint8_t vswitch_5v_magic[VSWITCH_MAGIC_LEN] = {
     'V', '5', 'V', '0'  // "V5V0" to indicate 5V mode
 };
 
+// LED color magic packet: 36-byte header + R, G, B, on/off = 40 bytes total
+#define LED_MAGIC_LEN 40
+#define LED_MAGIC_HEADER_LEN 36
+static uint8_t led_magic_header[LED_MAGIC_HEADER_LEN] = {
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE, 0xCA, 0xFE,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    0xDE, 0xAD, 0xBE, 0xEF, 0xDE, 0xAD, 0xBE, 0xEF,
+    'L', 'E', 'D', 'S'  // "LEDS" to indicate LED color command
+};
+
 #define PIN_SCK 0
 #define PIN_SIN 1
 #define TEST_PIN 6
@@ -450,6 +461,34 @@ void handle_input_data(uint8_t* buf_in, uint32_t count) {
     } else if(is_5v) {
       vswitch_set_5v();
       uint8_t ack = 0x35; // '5' for 5V
+      echo_all(&ack, 1);
+      processed = 1;
+    }
+  }
+
+  // Check for LED color magic sequence
+  if(!processed && count == LED_MAGIC_LEN) {
+    uint8_t is_led = 1;
+    for(int i = 0; i < LED_MAGIC_HEADER_LEN; i++) {
+      if(buf_in[i] != led_magic_header[i]) {
+        is_led = 0;
+        break;
+      }
+    }
+    if(is_led) {
+      uint8_t r = buf_in[LED_MAGIC_HEADER_LEN];
+      uint8_t g = buf_in[LED_MAGIC_HEADER_LEN + 1];
+      uint8_t b = buf_in[LED_MAGIC_HEADER_LEN + 2];
+      uint8_t on = buf_in[LED_MAGIC_HEADER_LEN + 3];
+      if(on) {
+        // NeoPixel expects GRB format
+        set_neopixel(((uint32_t)g << 16) | ((uint32_t)r << 8) | b);
+      } else {
+        set_neopixel(0x000000);
+      }
+      // Disable blink task from overriding the color
+      blink_interval_ms = BLINK_ALWAYS_ON;
+      uint8_t ack = 0x4C; // 'L' for LED
       echo_all(&ack, 1);
       processed = 1;
     }

--- a/main.c
+++ b/main.c
@@ -202,11 +202,9 @@ const tusb_desc_webusb_url_t desc_url =
 };
 
 static bool web_serial_connected = false;
-static bool send_firmware_version = false;
 
-// Firmware version string sent on WebSerial connect
-#define FIRMWARE_VERSION_STR "GBLINK:1.0.6\n"
-#define FIRMWARE_VERSION_LEN (sizeof(FIRMWARE_VERSION_STR) - 1)
+// Firmware version returned via control transfer (request 0x23)
+static const char FIRMWARE_VERSION_STR[] = "GBLINK:1.0.6";
 
 //------------- prototypes -------------//
 void handle_input_data(uint8_t* buf_in, uint32_t count);
@@ -371,7 +369,6 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
       if (web_serial_connected) {
         set_neopixel(0x000005); // Blue (Active)
         blink_interval_ms = BLINK_ALWAYS_ON;
-        send_firmware_version = true;
       } else {
         set_neopixel(0x050000); // Green (Mounted) - immediate feedback
         blink_interval_ms = BLINK_MOUNTED;
@@ -380,6 +377,10 @@ bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb_control_requ
       // response with status OK
       return tud_control_status(rhport, request);
       break;
+
+    case 0x23:
+      // Firmware version query
+      return tud_control_xfer(rhport, request, (void*)FIRMWARE_VERSION_STR, sizeof(FIRMWARE_VERSION_STR) - 1);
 
     default: break;
   }
@@ -531,20 +532,12 @@ void handle_input_data(uint8_t* buf_in, uint32_t count) {
 
 void webserial_task(void)
 {
-  if ( web_serial_connected ) {
-    // Send firmware version string once after WebSerial connect
-    if (send_firmware_version) {
-      send_firmware_version = false;
-      tud_vendor_write((uint8_t*)FIRMWARE_VERSION_STR, FIRMWARE_VERSION_LEN);
-      tud_vendor_flush();
-    }
-
+  if ( web_serial_connected )
     if ( tud_vendor_available() ) {
       uint8_t buf_in[MAX_TRANSFER_BYTES*2];
       uint32_t count = tud_vendor_read(buf_in, sizeof(buf_in));
       handle_input_data(buf_in, count);
     }
-  }
 }
 
 

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -75,9 +75,9 @@ uint8_t const * tud_descriptor_device_cb(void)
 //--------------------------------------------------------------------+
 enum
 {
-  ITF_NUM_VENDOR = 0, 
-  ITF_NUM_CDC,
+  ITF_NUM_CDC = 0,
   ITF_NUM_CDC_DATA,
+  ITF_NUM_VENDOR,
   ITF_NUM_TOTAL
 };
 
@@ -98,11 +98,11 @@ uint8_t const desc_configuration[] =
   // Config number, interface count, string index, total length, attribute, power in mA
   TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
 
-  // Interface number, string index, EP Out & IN address, EP size
-  TUD_VENDOR_DESCRIPTOR(ITF_NUM_VENDOR, 5, EPNUM_VENDOR, 0x80 | EPNUM_VENDOR, TUD_OPT_HIGH_SPEED ? 512 : 64),
-
   // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
   TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, 0x81, 8, EPNUM_CDC, 0x80 | EPNUM_CDC, TUD_OPT_HIGH_SPEED ? 512 : 64),
+
+  // Interface number, string index, EP Out & IN address, EP size
+  TUD_VENDOR_DESCRIPTOR(ITF_NUM_VENDOR, 5, EPNUM_VENDOR, 0x80 | EPNUM_VENDOR, TUD_OPT_HIGH_SPEED ? 512 : 64)
 };
 
 // Invoked when received GET CONFIGURATION DESCRIPTOR
@@ -239,3 +239,4 @@ uint16_t const* tud_descriptor_string_cb(uint8_t index, uint16_t langid)
 
   return _desc_str;
 }
+

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -75,9 +75,9 @@ uint8_t const * tud_descriptor_device_cb(void)
 //--------------------------------------------------------------------+
 enum
 {
-  ITF_NUM_CDC = 0,
+  ITF_NUM_VENDOR = 0, 
+  ITF_NUM_CDC,
   ITF_NUM_CDC_DATA,
-  ITF_NUM_VENDOR,
   ITF_NUM_TOTAL
 };
 
@@ -98,11 +98,11 @@ uint8_t const desc_configuration[] =
   // Config number, interface count, string index, total length, attribute, power in mA
   TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
 
+  // Interface number, string index, EP Out & IN address, EP size
+  TUD_VENDOR_DESCRIPTOR(ITF_NUM_VENDOR, 5, EPNUM_VENDOR, 0x80 | EPNUM_VENDOR, TUD_OPT_HIGH_SPEED ? 512 : 64),
+
   // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
   TUD_CDC_DESCRIPTOR(ITF_NUM_CDC, 4, 0x81, 8, EPNUM_CDC, 0x80 | EPNUM_CDC, TUD_OPT_HIGH_SPEED ? 512 : 64),
-
-  // Interface number, string index, EP Out & IN address, EP size
-  TUD_VENDOR_DESCRIPTOR(ITF_NUM_VENDOR, 5, EPNUM_VENDOR, 0x80 | EPNUM_VENDOR, TUD_OPT_HIGH_SPEED ? 512 : 64)
 };
 
 // Invoked when received GET CONFIGURATION DESCRIPTOR

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -54,7 +54,7 @@ tusb_desc_device_t const desc_device =
 
     .idVendor           = 0xCafe,
     .idProduct          = USB_PID,
-    .bcdDevice          = 0x0106,
+    .bcdDevice          = 0x0107,
 
     .iManufacturer      = 0x01,
     .iProduct           = 0x02,
@@ -136,8 +136,9 @@ https://developers.google.com/web/fundamentals/native-hardware/build-for-webusb/
 
 #define MS_OS_20_DESC_LEN  0xB2
 
-// BOS Descriptor is required for webUSB
-uint8_t const desc_bos[] =
+// BOS Descriptor is required for webUSB. Not const: iLandingPage is patched at
+// enumeration to reflect the persisted toggle (see tud_descriptor_bos_cb).
+uint8_t desc_bos[] =
 {
   // total length, number of device caps
   TUD_BOS_DESCRIPTOR(BOS_TOTAL_LEN, 2),
@@ -149,8 +150,15 @@ uint8_t const desc_bos[] =
   TUD_BOS_MS_OS_20_DESCRIPTOR(MS_OS_20_DESC_LEN, VENDOR_REQUEST_MICROSOFT)
 };
 
+// iLandingPage is the last byte of the WebUSB platform capability descriptor,
+// which follows the BOS header.
+#define WEBUSB_LANDING_PAGE_OFFSET (TUD_BOS_DESC_LEN + TUD_BOS_WEBUSB_DESC_LEN - 1)
+
 uint8_t const * tud_descriptor_bos_cb(void)
 {
+  // 1 = advertise the landing page (Chrome shows the "open launcher" prompt),
+  // 0 = no landing page. Persisted via the WebUSB "LAND" command.
+  desc_bos[WEBUSB_LANDING_PAGE_OFFSET] = landing_page_enabled() ? 1 : 0;
   return desc_bos;
 }
 

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -54,7 +54,7 @@ tusb_desc_device_t const desc_device =
 
     .idVendor           = 0xCafe,
     .idProduct          = USB_PID,
-    .bcdDevice          = 0x0106,
+    .bcdDevice          = 0x0107,
 
     .iManufacturer      = 0x01,
     .iProduct           = 0x02,

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -54,7 +54,7 @@ tusb_desc_device_t const desc_device =
 
     .idVendor           = 0xCafe,
     .idProduct          = USB_PID,
-    .bcdDevice          = 0x0107,
+    .bcdDevice          = 0x0106,
 
     .iManufacturer      = 0x01,
     .iProduct           = 0x02,

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -54,7 +54,7 @@ tusb_desc_device_t const desc_device =
 
     .idVendor           = 0xCafe,
     .idProduct          = USB_PID,
-    .bcdDevice          = 0x0100,
+    .bcdDevice          = 0x0106,
 
     .iManufacturer      = 0x01,
     .iProduct           = 0x02,

--- a/usb_descriptors.h
+++ b/usb_descriptors.h
@@ -25,6 +25,9 @@
 #ifndef USB_DESCRIPTORS_H_
 #define USB_DESCRIPTORS_H_
 
+#include <stdint.h>
+#include <stdbool.h>
+
 enum
 {
   VENDOR_REQUEST_WEBUSB = 1,
@@ -32,5 +35,10 @@ enum
 };
 
 extern uint8_t const desc_ms_os_20[];
+
+// WebUSB landing-page advertising, persisted in flash (default = enabled).
+// Defined in main.c; the BOS descriptor callback reads it at enumeration.
+bool landing_page_enabled(void);
+void set_landing_page_enabled(bool enabled);
 
 #endif /* USB_DESCRIPTORS_H_ */


### PR DESCRIPTION
Backwards compatible update to add automatic .uf2 release and optional status LED for status LED for RP2040-Zero boards. Also adds a readme.